### PR TITLE
atm90e32: show saved calibration logs after API connects

### DIFF
--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -231,6 +231,10 @@ class ATM90E32Component : public PollingComponent,
   bool peak_current_signed_{false};
   bool enable_offset_calibration_{false};
   bool enable_gain_calibration_{false};
+  bool restored_offset_calibration_{false};
+  bool restored_power_offset_calibration_{false};
+  bool restored_gain_calibration_{false};
+  bool calibration_message_printed_{false};
 };
 
 }  // namespace atm90e32


### PR DESCRIPTION
## Summary
- ensure ATM90E32 prints calibration restoration messages when an API client connects, fixing missing OTA logs
- track whether gain, offset, and power offset calibrations were loaded from flash

## Testing
- `pre-commit run --files esphome/components/atm90e32/atm90e32.cpp esphome/components/atm90e32/atm90e32.h`
- `pytest tests/components/atm90e32`

------
https://chatgpt.com/codex/tasks/task_e_688f8225828c83239c79eb5e7b8885f5