### PR TITLE
Optimize ATM90E32 SPI transfers for sequential sensor reads

### DIFF
--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -337,28 +337,35 @@ float ATM90E32Component::get_setup_priority() const { return setup_priority::IO;
 // R/C registers can conly be cleared after the LastSPIData register is updated (register 78H)
 // Peakdetect period: 05H. Bit 15:8 are PeakDet_period in ms. 7:0 are Sag_period
 // Default is 143FH (20ms, 63ms)
-uint16_t ATM90E32Component::read16_(uint16_t a_register) {
+uint16_t ATM90E32Component::read16_transaction_(uint16_t a_register) {
   uint8_t addrh = (1 << 7) | ((a_register >> 8) & 0x03);
   uint8_t addrl = (a_register & 0xFF);
-  uint8_t data[2];
-  uint16_t output;
-  this->enable();
-  delay_microseconds_safe(1);  // min delay between CS low and first SCK is 200ns - 1us is plenty
-  this->write_byte(addrh);
-  this->write_byte(addrl);
-  this->read_array(data, 2);
-  delay_microseconds_safe(1);  // allow the last clock to propagate before releasing CS
-  this->disable();
-  delay_microseconds_safe(1);  // meet minimum CS high time before next transaction
-
-  output = (uint16_t(data[0] & 0xFF) << 8) | (data[1] & 0xFF);
+  uint8_t data[4] = {addrh, addrl, 0x00, 0x00};
+  this->transfer_array(data, 4);
+  uint16_t output = (uint16_t(data[2] & 0xFF) << 8) | (data[3] & 0xFF);
   ESP_LOGVV(TAG, "read16_ 0x%04" PRIX16 " output 0x%04" PRIX16, a_register, output);
   return output;
 }
 
+uint16_t ATM90E32Component::read16_(uint16_t a_register) {
+  this->enable();
+  delay_microseconds_safe(1);  // min delay between CS low and first SCK is 200ns - 1us is plenty
+  uint16_t output = this->read16_transaction_(a_register);
+  delay_microseconds_safe(1);  // allow the last clock to propagate before releasing CS
+  this->disable();
+  delay_microseconds_safe(1);  // meet minimum CS high time before next transaction
+  return output;
+}
+
 int ATM90E32Component::read32_(uint16_t addr_h, uint16_t addr_l) {
-  const uint16_t val_h = this->read16_(addr_h);
-  const uint16_t val_l = this->read16_(addr_l);
+  this->enable();
+  delay_microseconds_safe(1);
+  const uint16_t val_h = this->read16_transaction_(addr_h);
+  delay_microseconds_safe(1);
+  const uint16_t val_l = this->read16_transaction_(addr_l);
+  delay_microseconds_safe(1);
+  this->disable();
+  delay_microseconds_safe(1);
   const int32_t val = (val_h << 16) | val_l;
 
   ESP_LOGVV(TAG,
@@ -371,10 +378,12 @@ int ATM90E32Component::read32_(uint16_t addr_h, uint16_t addr_l) {
 
 void ATM90E32Component::write16_(uint16_t a_register, uint16_t val) {
   ESP_LOGVV(TAG, "write16_ 0x%04" PRIX16 " val 0x%04" PRIX16, a_register, val);
+  uint8_t addrh = ((a_register >> 8) & 0x03);
+  uint8_t addrl = (a_register & 0xFF);
+  uint8_t data[4] = {addrh, addrl, uint8_t((val >> 8) & 0xFF), uint8_t(val & 0xFF)};
   this->enable();
   delay_microseconds_safe(1);  // ensure CS setup time
-  this->write_byte16(a_register);
-  this->write_byte16(val);
+  this->write_array(data, 4);
   delay_microseconds_safe(1);  // allow clock to settle before raising CS
   this->disable();
   delay_microseconds_safe(1);  // ensure minimum CS high time

--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -140,6 +140,7 @@ class ATM90E32Component : public PollingComponent,
   number::Number *ref_currents_[3]{nullptr, nullptr, nullptr};
 #endif
   uint16_t read16_(uint16_t a_register);
+  uint16_t read16_transaction_(uint16_t a_register);
   int read32_(uint16_t addr_h, uint16_t addr_l);
   void write16_(uint16_t a_register, uint16_t val);
   float get_local_phase_voltage_(uint8_t phase);


### PR DESCRIPTION
## Summary
- reduce SPI overhead by performing single transfer for 16-bit reads/writes
- keep chip-select active for multi-register reads to minimize bus toggling