### PR TITLE
Fix ATM90E32 calibration restoration logic

### DIFF
--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -781,14 +781,17 @@ void ATM90E32Component::restore_gain_calibrations_() {
 
   if (this->gain_calibration_pref_.load(&this->gain_phase_)) {
     bool all_zero = true;
+    bool same_as_config = true;
     for (uint8_t phase = 0; phase < 3; ++phase) {
-      if (this->gain_phase_[phase].voltage_gain != 0 || this->gain_phase_[phase].current_gain != 0) {
+      const auto &cfg = this->config_gain_phase_[phase];
+      const auto &saved = this->gain_phase_[phase];
+      if (saved.voltage_gain != 0 || saved.current_gain != 0)
         all_zero = false;
-        break;
-      }
+      if (saved.voltage_gain != cfg.voltage_gain || saved.current_gain != cfg.current_gain)
+        same_as_config = false;
     }
 
-    if (!all_zero) {
+    if (!all_zero && !same_as_config) {
       for (uint8_t phase = 0; phase < 3; ++phase) {
         bool mismatch = false;
         if (this->has_config_voltage_gain_[phase] &&

--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -832,8 +832,8 @@ void ATM90E32Component::restore_offset_calibrations_() {
   bool have_data = this->offset_pref_.load(&this->offset_phase_);
   bool all_zero = true;
   if (have_data) {
-    for (uint8_t phase = 0; phase < 3; phase++) {
-      if (this->offset_phase_[phase].voltage_offset_ != 0 || this->offset_phase_[phase].current_offset_ != 0) {
+    for (auto &phase : this->offset_phase_) {
+      if (phase.voltage_offset_ != 0 || phase.current_offset_ != 0) {
         all_zero = false;
         break;
       }
@@ -861,9 +861,10 @@ void ATM90E32Component::restore_offset_calibrations_() {
              this->cs_->dump_summary().c_str());
   }
 
-  for (uint8_t phase = 0; phase < 3; phase++)
+  for (uint8_t phase = 0; phase < 3; phase++) {
     write_offsets_to_registers_(phase, this->offset_phase_[phase].voltage_offset_,
                                 this->offset_phase_[phase].current_offset_);
+  }
 }
 
 void ATM90E32Component::restore_power_offset_calibrations_() {
@@ -873,9 +874,8 @@ void ATM90E32Component::restore_power_offset_calibrations_() {
   bool have_data = this->power_offset_pref_.load(&this->power_offset_phase_);
   bool all_zero = true;
   if (have_data) {
-    for (uint8_t phase = 0; phase < 3; ++phase) {
-      if (this->power_offset_phase_[phase].active_power_offset != 0 ||
-          this->power_offset_phase_[phase].reactive_power_offset != 0) {
+    for (auto &phase : this->power_offset_phase_) {
+      if (phase.active_power_offset != 0 || phase.reactive_power_offset != 0) {
         all_zero = false;
         break;
       }
@@ -903,9 +903,10 @@ void ATM90E32Component::restore_power_offset_calibrations_() {
              this->cs_->dump_summary().c_str());
   }
 
-  for (uint8_t phase = 0; phase < 3; ++phase)
+  for (uint8_t phase = 0; phase < 3; ++phase) {
     write_power_offsets_to_registers_(phase, this->power_offset_phase_[phase].active_power_offset,
                                       this->power_offset_phase_[phase].reactive_power_offset);
+  }
 }
 
 void ATM90E32Component::clear_gain_calibrations() {


### PR DESCRIPTION
## Summary
- ensure gain calibration uses configuration values
- treat zeroed calibrations as absent and reload defaults