### PR TITLE
Refactor ATM90E32 calibration logging

### DIFF
--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -180,6 +180,7 @@ class ATM90E32Component : public PollingComponent,
   void write_gains_to_registers_();
   bool verify_gain_writes_();
   bool validate_spi_read_(uint16_t expected, const char *context = nullptr);
+  void log_calibration_status_();
 
   struct ATM90E32Phase {
     uint16_t voltage_gain_{0};


### PR DESCRIPTION
## Summary
- factor calibration mismatch logging into helper
- invoke logging from dump_config for OTA visibility