### PR TITLE
Store CS pin summary for ATM90E32 logs

### DIFF
--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -246,6 +246,7 @@ class ATM90E32Component : public PollingComponent,
   ESPPreferenceObject offset_pref_;
   ESPPreferenceObject power_offset_pref_;
   ESPPreferenceObject gain_calibration_pref_;
+  std::string cs_summary_;
 
   sensor::Sensor *freq_sensor_{nullptr};
 #ifdef USE_TEXT_SENSOR


### PR DESCRIPTION
## Summary
- cache ATM90E32 chip-select pin description for reuse across logs
- reuse cached summary via local `const char*` in calibration helpers

## Testing
- `pre-commit run --files esphome/components/atm90e32/atm90e32.cpp esphome/components/atm90e32/atm90e32.h`
- `pytest tests/components/atm90e32`


------
https://chatgpt.com/codex/tasks/task_e_6899fd480c148323b4704670bc81d211