### PR TITLE
atm90e32: persist offset calibrations

### DIFF
--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -174,7 +174,9 @@ class ATM90E32Component : public PollingComponent,
   void restore_offset_calibrations_();
   void restore_power_offset_calibrations_();
   void restore_gain_calibrations_();
+  void save_offset_calibration_to_memory_();
   void save_gain_calibration_to_memory_();
+  void save_power_offset_calibration_to_memory_();
   void write_offsets_to_registers_(uint8_t phase, int16_t voltage_offset, int16_t current_offset);
   void write_power_offsets_to_registers_(uint8_t phase, int16_t p_offset, int16_t q_offset);
   void write_gains_to_registers_();


### PR DESCRIPTION
## Summary
- save ATM90E32 power offset calibration to flash with logging
- mark offset calibrations as stored so they can be cleared
- compute power offset calibration using signed average to avoid constant 1 values
- add helper to save voltage/current offset calibration to memory

## Testing
- `pre-commit run --files esphome/components/atm90e32/atm90e32.cpp esphome/components/atm90e32/atm90e32.h`
- `pytest tests/components/atm90e32` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689a1401064c83239b3f21742f7067a8